### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/farmlinkage/597362b3-608a-40e3-bb49-21ef24429f7d/a155ef97-e26a-48ab-8d4d-ec1f18a1e94d/_apis/work/boardbadge/faec1b0a-c14d-446d-a110-029aee454206)](https://dev.azure.com/farmlinkage/597362b3-608a-40e3-bb49-21ef24429f7d/_boards/board/t/a155ef97-e26a-48ab-8d4d-ec1f18a1e94d/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/farmlinkage/597362b3-608a-40e3-bb49-21ef24429f7d/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.